### PR TITLE
fix missing lookahead

### DIFF
--- a/src/dispatcher.js
+++ b/src/dispatcher.js
@@ -268,7 +268,7 @@ class CommandDispatcher {
 		if(prefix) {
 			const escapedPrefix = escapeRegex(prefix);
 			pattern = new RegExp(
-				`^(${escapedPrefix}\\s*|<@!?${this.client.user.id}>\\s+(?:${escapedPrefix})?)([^\\s]+)`, 'i'
+				`^(${escapedPrefix}\\s*|<@!?${this.client.user.id}>\\s+(?:${escapedPrefix})?)([^${escapedPrefix}\\s]+)`, 'i'
 			);
 		} else {
 			pattern = new RegExp(`(^<@!?${this.client.user.id}>\\s+)([^\\s]+)`, 'i');


### PR DESCRIPTION
the command prefix should match as given - with undocumented space as separator wildcard it should not allow the prefix to re-appear rather than perform lookahead, removes errors like ``{pref}{pref}{pref}{pref}\s\s{pref}`` and such